### PR TITLE
Various fixes

### DIFF
--- a/source/girtod.d
+++ b/source/girtod.d
@@ -31,7 +31,7 @@ void main(string[] args)
 {
 
 	bool printFree;
-	bool useRuntimeLinker = true;
+	bool useRuntimeLinker;
 	string inputDir;
 	string outputDir;
 

--- a/source/gtd/GtkPackage.d
+++ b/source/gtd/GtkPackage.d
@@ -341,9 +341,9 @@ class GtkPackage
 		buff ~= "import "~ bindDir ~"."~ name ~"types;\n";
 
 		if ( name == "glib" )
-			buff ~= "import gtkc.gobjecttypes;\n";
+			buff ~= "import " ~ bindDir ~ ".gobjecttypes;\n";
 		if ( name == "gdk" || name == "pango" )
-			buff ~= "import gtkc.cairotypes;\n";
+			buff ~= "import " ~ bindDir ~ ".cairotypes;\n";
 
 		buff ~= "import gtkd.Loader;\n"
 			~ "import gtkd.paths;\n\n"
@@ -429,9 +429,9 @@ class GtkPackage
 		buff ~= "import "~ bindDir ~"."~ name ~"types;\n";
 
 		if ( name == "glib" )
-			buff ~= "import gtkc.gobjecttypes;\n";
+			buff ~= "import " ~ bindDir ~ ".gobjecttypes;\n";
 		if ( name == "gdk" || name == "pango" )
-			buff ~= "import gtkc.cairotypes;\n";
+			buff ~= "import " ~ bindDir ~ ".cairotypes;\n";
 
 		buff ~= "\n\n__gshared extern(C)\n"
 			~ "{\n";

--- a/source/gtd/GtkStruct.d
+++ b/source/gtd/GtkStruct.d
@@ -776,8 +776,6 @@ final class GtkStruct
 			{
 				imports ~= "std.algorithm";
 				imports ~= "gobject.Signals";
-				imports ~= "gtkc.gdktypes";
-
 			}
 
 			if ( func.type == GtkFunctionType.Constructor )

--- a/source/gtd/GtkWrapper.d
+++ b/source/gtd/GtkWrapper.d
@@ -481,16 +481,16 @@ class GtkWrapper
 		if ( file == "cairo" )
 		{
 			if ( useRuntimeLinker )
-				copy(buildNormalizedPath(to, "gtkc/cairo-runtime.d"), buildNormalizedPath(to, "../gtkc/cairo.d"));
+				copy(buildNormalizedPath(to, bindDir, "cairo-runtime.d"), buildNormalizedPath(to, "..", bindDir, "cairo.d"));
 			else
-				copy(buildNormalizedPath(to, "gtkc/cairo-compiletime.d"), buildNormalizedPath(to, "../gtkc/cairo.d"));
+				copy(buildNormalizedPath(to, bindDir, "cairo-compiletime.d"), buildNormalizedPath(to, "..", bindDir, "cairo.d"));
 
-			copy(buildNormalizedPath(to, "gtkc/cairotypes.d"), buildNormalizedPath(to, "../gtkc/cairotypes.d"));
+			copy(buildNormalizedPath(to, bindDir, "cairotypes.d"), buildNormalizedPath(to, "..", bindDir, "cairotypes.d"));
 
-			remove(buildNormalizedPath(to, "gtkc/cairo-runtime.d"));
-			remove(buildNormalizedPath(to, "gtkc/cairo-compiletime.d"));
-			remove(buildNormalizedPath(to, "gtkc/cairotypes.d"));
-			remove(buildNormalizedPath(to, "gtkc"));
+			remove(buildNormalizedPath(to, bindDir, "cairo-runtime.d"));
+			remove(buildNormalizedPath(to, bindDir, "cairo-compiletime.d"));
+			remove(buildNormalizedPath(to, bindDir, "cairotypes.d"));
+			remove(buildNormalizedPath(to, bindDir));
 		}
 	}
 


### PR DESCRIPTION
Hi!
With GirToD gaining support for generating bindings without the need for runtime library loading, and with its new flags allowing for running the generator at build-time in other projects, I can finally replace my quick&dirty fork of the project, yay!

A few quirks remain which this PR resolves:
  * Actually allow for not using the runtime linker (looks like a typo that it didn't work ^^)
  * Removing a gdktypes import: I only use the GLib/GObject/GIO bindings and other non-GUI stuff, so having this messes with that code. It also appears like that this import actually didn't do anything, so it should be safe to remove.
 * Remove hardcoded gtkc binDir: Pretty self explanatory. I think the docs and maybe a runtime check should disallow binDir to be anything other than a single string - as soon as people put dots and slashes into that variable, we will be in trouble.

In general I think it would make sense to move the essential GIR wrap pieces (GLib/GIO/GObject) to this project too, as they are needed for almost every project using GIR. Also, the dynamic library loader seems to be missing here.

With the wrap files in this repo and the GUI stuff separated from the non-GUI stuff, we could use this to generate GLib D bindings in Debian without many issues and keep them up to date, which would be absolutely fantastic!

I have a small fork of the respective wrap files in the AppStream generator repo, and I would love to get rid of them at some point: https://github.com/ximion/appstream-generator/tree/master/contrib/girwrap
The changes are mostly renaming gtkc -> gi and getting rid of references to the dynamic linker to make everything compile.

Thank you very much for your work on this!